### PR TITLE
[codex] 支持 Steam 折扣断点续扫

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ config/exchange_rate.json
 config/steam_userdata.json
 config/holdings_report_last.json
 config/transactions.json.bak
+config/steam_deals_checkpoint.json
+config/steam_deals_checkpoint.json.tmp
 
 # 日志
 log/

--- a/app/database.py
+++ b/app/database.py
@@ -462,6 +462,26 @@ def db_clear_steam_deals() -> None:
     with get_session() as session:
         session.exec(sql_delete(SteamDealGame))
         session.commit()
+def db_delete_steam_deals_except(app_ids: List[str]) -> int:
+    """Delete Steam deal rows whose app_id is not in the latest scan set."""
+    from sqlmodel import col, delete as sql_delete
+    keep = {str(app_id) for app_id in app_ids if app_id}
+    if not keep:
+        return 0
+    with get_session() as session:
+        existing = session.exec(select(SteamDealGame.app_id)).all()
+        stale = [str(app_id) for app_id in existing if str(app_id) not in keep]
+        deleted = 0
+        for i in range(0, len(stale), 500):
+            chunk = stale[i:i + 500]
+            if not chunk:
+                continue
+            session.exec(
+                sql_delete(SteamDealGame).where(col(SteamDealGame.app_id).in_(chunk))
+            )
+            deleted += len(chunk)
+        session.commit()
+        return deleted
 def db_get_steam_deals_price_snapshot() -> list:
     """Lightweight fetch: only price-related columns for ALL games.
     Used to build an in-memory sort index (price_diff / discount_abs) without

--- a/app/routes/steam_deals.py
+++ b/app/routes/steam_deals.py
@@ -285,6 +285,14 @@ def api_fetch_steam_deals(force_refresh: bool = Query(False)):
     )
     t.start()
     return {"ok": True, "message": "已开始获取"}
+@router.post("/api/steam-deals/pause")
+def api_pause_steam_deals():
+    """请求暂停当前 Steam 折扣抓取任务."""
+    from app.services.steam_deals import request_pause
+
+    if not request_pause():
+        return {"ok": False, "error": "当前没有正在运行的抓取任务"}
+    return {"ok": True, "message": "已请求暂停，当前请求完成后会保存进度"}
 @router.get("/api/steam-deals/status")
 def api_steam_deals_status():
     """获取抓取状态和上次更新时间."""
@@ -301,6 +309,7 @@ def api_steam_deals_status():
         "total": state["total"],
         "failed": state["failed"],
         "message": state["message"],
+        "pause_requested": state.get("pause_requested", False),
         "last_update": last_update,
         "total_games_in_db": total_games,
         "auto_refresh_days": auto_refresh_days,

--- a/app/routes/steam_deals.py
+++ b/app/routes/steam_deals.py
@@ -257,7 +257,7 @@ def api_exchange_rates():
     rates = _load_exchange_rates()
     return {"rates": rates, "region_currency": _REGION_CURRENCY}
 @router.post("/api/steam-deals/fetch")
-def api_fetch_steam_deals():
+def api_fetch_steam_deals(force_refresh: bool = Query(False)):
     from app.services.steam_deals import get_fetch_state, run_fetch
 
     state = get_fetch_state()
@@ -280,7 +280,7 @@ def api_fetch_steam_deals():
 
     t = threading.Thread(
         target=run_fetch,
-        args=(max_games, max_regions),
+        args=(max_games, max_regions, force_refresh),
         daemon=True,
     )
     t.start()
@@ -288,8 +288,9 @@ def api_fetch_steam_deals():
 @router.get("/api/steam-deals/status")
 def api_steam_deals_status():
     """获取抓取状态和上次更新时间."""
-    from app.services.steam_deals import get_fetch_state
+    from app.services.steam_deals import get_fetch_state, get_resume_state
     state = get_fetch_state()
+    resume_state = get_resume_state()
     last_update = db_get_steam_deals_last_update()
     total_games = db_get_steam_deals_count()
     cfg = load_app_config_validated()
@@ -303,6 +304,7 @@ def api_steam_deals_status():
         "last_update": last_update,
         "total_games_in_db": total_games,
         "auto_refresh_days": auto_refresh_days,
+        "resume": resume_state,
     }
 
 @router.post("/api/steam-deals/generate-card/{app_id}")

--- a/app/services/steam_deals.py
+++ b/app/services/steam_deals.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Optional
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+ROOT = Path(__file__).resolve().parent.parent.parent
+CHECKPOINT_FILE = ROOT / "config" / "steam_deals_checkpoint.json"
+CHECKPOINT_VERSION = 1
 REGIONS = {
     '中国': 'cn', '俄罗斯': 'ru', '哈萨克斯坦': 'kz', '乌克兰': 'ua',
     '南亚': 'pk', '土耳其': 'tr', '阿根廷': 'ar', '阿塞拜疆': 'az',
@@ -40,6 +43,74 @@ def get_fetch_state() -> dict:
 def _update_state(**kwargs):
     with _fetch_lock:
         _fetch_state.update(kwargs)
+def _load_checkpoint() -> Optional[dict]:
+    """Load persisted scan progress, if available."""
+    try:
+        if not CHECKPOINT_FILE.exists():
+            return None
+        with open(CHECKPOINT_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if data.get("version") != CHECKPOINT_VERSION:
+            return None
+        appids = data.get("appids")
+        if not isinstance(appids, list) or not appids:
+            return None
+        data["appids"] = [str(appid) for appid in appids if appid]
+        data["done"] = [str(appid) for appid in data.get("done", []) if appid]
+        failed = data.get("failed", {})
+        if isinstance(failed, list):
+            failed = {str(appid): "" for appid in failed if appid}
+        elif isinstance(failed, dict):
+            failed = {str(k): str(v) for k, v in failed.items() if k}
+        else:
+            failed = {}
+        data["failed"] = failed
+        return data
+    except Exception:
+        return None
+def _save_checkpoint(data: dict) -> None:
+    """Atomically persist scan progress so an interrupted run can resume."""
+    try:
+        CHECKPOINT_FILE.parent.mkdir(parents=True, exist_ok=True)
+        payload = dict(data)
+        payload["version"] = CHECKPOINT_VERSION
+        payload["updated_at"] = time.time()
+        tmp_path = CHECKPOINT_FILE.with_suffix(".json.tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        tmp_path.replace(CHECKPOINT_FILE)
+    except Exception:
+        pass
+def _clear_checkpoint() -> None:
+    try:
+        CHECKPOINT_FILE.unlink(missing_ok=True)
+    except Exception:
+        pass
+def get_resume_state() -> dict:
+    """Return persisted checkpoint status for the UI."""
+    cp = _load_checkpoint()
+    if not cp:
+        return {
+            "has_checkpoint": False,
+            "progress": 0,
+            "total": 0,
+            "failed": 0,
+            "updated_at": None,
+            "started_at": None,
+            "status": None,
+        }
+    done = set(cp.get("done", []))
+    failed = cp.get("failed", {}) or {}
+    appids = cp.get("appids", [])
+    return {
+        "has_checkpoint": True,
+        "progress": len(done),
+        "total": len(appids),
+        "failed": len(failed),
+        "updated_at": cp.get("updated_at"),
+        "started_at": cp.get("started_at"),
+        "status": cp.get("status"),
+    }
 def _build_valid_proxies() -> list:
     """Read proxies from app config, test them, return sorted valid ones."""
     try:
@@ -315,12 +386,14 @@ def _process_single_game(appid: str, valid_proxies: list, max_region_threads: in
     if valid_price_count < _MIN_VALID_REGIONS:
         return None
     return game_data
-def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16):
+def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_refresh: bool = False):
     """
     Main entry: build proxy pool, fetch appids, process games concurrently.
+    Progress is saved to config/steam_deals_checkpoint.json so interrupted
+    scans can continue without losing already-written rows.
     Designed to be called in a background thread.
     """
-    from app.database import db_upsert_steam_deal, db_clear_steam_deals
+    from app.database import db_upsert_steam_deal, db_clear_steam_deals, db_delete_steam_deals_except
     with _fetch_lock:
         if _fetch_state["running"]:
             return
@@ -332,21 +405,64 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16):
             "message": "🚀 开始获取...",
         })
     try:
+        if force_refresh:
+            _update_state(message="🧹 正在重置旧进度和旧数据...")
+            _clear_checkpoint()
+            db_clear_steam_deals()
         valid_proxies = _build_valid_proxies()
         if not valid_proxies:
             _update_state(message="⚠️ 无可用代理，尝试直连...")
-        _update_state(message="🗑️ 正在清空旧数据...")
-        db_clear_steam_deals()
-        appids = _get_discounted_appids(max_count=20000, valid_proxies=valid_proxies)
+        checkpoint = None if force_refresh else _load_checkpoint()
+        resumed = bool(checkpoint)
+        if resumed:
+            appids = checkpoint.get("appids", [])
+            done_set = set(checkpoint.get("done", []))
+            failed_map = dict(checkpoint.get("failed", {}) or {})
+            _update_state(
+                total=len(appids),
+                progress=len(done_set),
+                failed=len(failed_map),
+                message=f"🔁 检测到未完成任务，继续扫描 {len(appids) - len(done_set)} 款游戏...",
+            )
+        else:
+            appids = _get_discounted_appids(max_count=20000, valid_proxies=valid_proxies)
+            done_set = set()
+            failed_map = {}
+            if appids:
+                checkpoint = {
+                    "version": CHECKPOINT_VERSION,
+                    "status": "running",
+                    "started_at": time.time(),
+                    "appids": appids,
+                    "done": [],
+                    "failed": {},
+                    "force_refresh": bool(force_refresh),
+                }
+                _save_checkpoint(checkpoint)
         if not appids:
             _update_state(running=False, message="❌ 未获取到任何游戏 ID")
             return
+        remaining_appids = [appid for appid in appids if str(appid) not in done_set]
+        if not remaining_appids:
+            deleted = db_delete_steam_deals_except(appids)
+            _clear_checkpoint()
+            _update_state(
+                running=False,
+                progress=len(appids),
+                total=len(appids),
+                failed=0,
+                message=f"🎉 已全部完成！清理过期记录 {deleted} 款",
+            )
+            return
         _update_state(
             total=len(appids),
-            progress=0,
-            message=f"⛏️ 开始处理 {len(appids)} 款游戏 ({max_game_threads}x{max_region_threads} 并发)...",
+            progress=len(done_set),
+            message=f"⛏️ 开始处理 {len(remaining_appids)}/{len(appids)} 款游戏 ({max_game_threads}x{max_region_threads} 并发)...",
         )
-        fx_file = Path(__file__).resolve().parent.parent.parent / "config" / "exchange_rate.json"
+        order_index = {str(appid): i for i, appid in enumerate(appids)}
+        def _ordered_done() -> List[str]:
+            return sorted(done_set, key=lambda x: order_index.get(str(x), len(order_index)))
+        fx_file = ROOT / "config" / "exchange_rate.json"
         rates = {}
         try:
             if fx_file.exists():
@@ -357,37 +473,74 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16):
         with ThreadPoolExecutor(max_workers=max_game_threads) as executor:
             future_map = {
                 executor.submit(_process_single_game, appid, valid_proxies, max_region_threads, rates): appid
-                for appid in appids
+                for appid in remaining_appids
             }
-            count = 0
-            failed = 0
+            count = len(done_set)
             for future in as_completed(future_map):
+                appid = str(future_map[future])
                 count += 1
                 try:
                     game = future.result()
                     if game is None:
-                        failed += 1
+                        done_set.add(appid)
+                        failed_map.pop(appid, None)
                         _update_state(
                             progress=count,
-                            failed=failed,
+                            failed=len(failed_map),
                             message=f"⏭️ [{count}/{len(appids)}] 质量不达标，跳过",
                         )
                     else:
                         db_upsert_steam_deal(game)
+                        done_set.add(appid)
+                        failed_map.pop(appid, None)
                         _update_state(
                             progress=count,
+                            failed=len(failed_map),
                             message=f"✅ [{count}/{len(appids)}] {game['name']}",
                         )
                 except Exception as e:
-                    failed += 1
+                    failed_map[appid] = str(e)[:120]
                     _update_state(
                         progress=count,
-                        failed=failed,
+                        failed=len(failed_map),
                         message=f"⚠️ [{count}/{len(appids)}] 处理失败: {str(e)[:60]}",
                     )
+                if checkpoint is not None:
+                    checkpoint.update({
+                        "status": "running",
+                        "appids": appids,
+                        "done": _ordered_done(),
+                        "failed": failed_map,
+                        "last_progress": count,
+                    })
+                    _save_checkpoint(checkpoint)
+        if failed_map:
+            if checkpoint is not None:
+                checkpoint.update({
+                    "status": "incomplete",
+                    "done": _ordered_done(),
+                    "failed": failed_map,
+                    "completed_at": time.time(),
+                })
+                _save_checkpoint(checkpoint)
+            _update_state(
+                running=False,
+                progress=count,
+                failed=len(failed_map),
+                message=f"⚠️ 本轮完成，仍有 {len(failed_map)} 款失败；再次点击可继续补扫",
+            )
+            return
+        deleted = db_delete_steam_deals_except(appids)
+        _clear_checkpoint()
         _update_state(
             running=False,
-            message=f"🎉 完成！共处理 {count} 款游戏，失败 {failed} 款",
+            failed=0,
+            message=f"🎉 完成！共处理 {count} 款游戏，清理过期记录 {deleted} 款",
         )
     except Exception as e:
+        checkpoint = _load_checkpoint()
+        if checkpoint:
+            checkpoint["status"] = "interrupted"
+            checkpoint["last_error"] = str(e)[:200]
+            _save_checkpoint(checkpoint)
         _update_state(running=False, message=f"❌ 抓取出错: {str(e)[:100]}")

--- a/app/services/steam_deals.py
+++ b/app/services/steam_deals.py
@@ -11,7 +11,7 @@ import requests
 import urllib3
 import json
 from pathlib import Path
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
 from typing import List, Optional
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -30,12 +30,14 @@ USER_AGENTS = [
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Edge/122.0.0.0 Safari/537.36",
 ]
 _fetch_lock = threading.Lock()
+_pause_event = threading.Event()
 _fetch_state = {
     "running": False,
     "progress": 0,        
     "total": 0,           
     "failed": 0,          
-    "message": "",        
+    "message": "",
+    "pause_requested": False,
 }
 def get_fetch_state() -> dict:
     with _fetch_lock:
@@ -43,6 +45,21 @@ def get_fetch_state() -> dict:
 def _update_state(**kwargs):
     with _fetch_lock:
         _fetch_state.update(kwargs)
+def request_pause() -> bool:
+    """Ask the running fetch worker to stop after the current safe checkpoint."""
+    with _fetch_lock:
+        if not _fetch_state.get("running"):
+            return False
+        _fetch_state["pause_requested"] = True
+        _fetch_state["message"] = "⏸️ 正在暂停，等待当前请求完成..."
+    _pause_event.set()
+    return True
+def _pause_requested() -> bool:
+    return _pause_event.is_set()
+def _clear_pause_request() -> None:
+    _pause_event.clear()
+    with _fetch_lock:
+        _fetch_state["pause_requested"] = False
 def _load_checkpoint() -> Optional[dict]:
     """Load persisted scan progress, if available."""
     try:
@@ -52,8 +69,11 @@ def _load_checkpoint() -> Optional[dict]:
             data = json.load(f)
         if data.get("version") != CHECKPOINT_VERSION:
             return None
-        appids = data.get("appids")
-        if not isinstance(appids, list) or not appids:
+        appids = data.get("appids", [])
+        phase = data.get("phase")
+        if not isinstance(appids, list):
+            return None
+        if not appids and phase != "discovering":
             return None
         data["appids"] = [str(appid) for appid in appids if appid]
         data["done"] = [str(appid) for appid in data.get("done", []) if appid]
@@ -98,18 +118,23 @@ def get_resume_state() -> dict:
             "updated_at": None,
             "started_at": None,
             "status": None,
+            "phase": None,
         }
     done = set(cp.get("done", []))
     failed = cp.get("failed", {}) or {}
     appids = cp.get("appids", [])
+    phase = cp.get("phase")
+    progress = len(appids) if phase == "discovering" else len(done)
+    total = cp.get("total_count") or len(appids)
     return {
         "has_checkpoint": True,
-        "progress": len(done),
-        "total": len(appids),
+        "progress": progress,
+        "total": total,
         "failed": len(failed),
         "updated_at": cp.get("updated_at"),
         "started_at": cp.get("started_at"),
         "status": cp.get("status"),
+        "phase": phase,
     }
 def _build_valid_proxies() -> list:
     """Read proxies from app config, test them, return sorted valid ones."""
@@ -174,18 +199,43 @@ def _fetch_with_proxy(url: str, valid_proxies: list, max_retries: int = 5):
         except Exception:
             continue
     return None
-def _get_discounted_appids(max_count: int = 20000, valid_proxies: Optional[list] = None) -> List[str]:
+def _get_discounted_appids(max_count: int = 20000, valid_proxies: Optional[list] = None, checkpoint: Optional[dict] = None) -> List[str]:
     """Fetch discounted game AppIDs from Steam search API, up to max_count.
     Uses Steam's native search endpoint with specials=1 filter, paginated via
     the `start` offset parameter (max 100 per page). Every request is routed
     through the proxy pool to avoid rate-limiting (HTTP 429).
     """
-    _update_state(message=f"🕵️ 正在从 Steam 获取打折游戏列表 (上限 {max_count})...")
     appids: List[str] = []
     seen: set = set()
     start = 0
     page_size = 100
     total_count: Optional[int] = None
+    consecutive_empty = 0
+    if checkpoint and checkpoint.get("phase") == "discovering":
+        appids = [str(appid) for appid in checkpoint.get("appids", []) if appid]
+        seen = set(appids)
+        start = int(checkpoint.get("discovery_start", 0) or 0)
+        total_count = checkpoint.get("total_count")
+        consecutive_empty = int(checkpoint.get("consecutive_empty", 0) or 0)
+        _update_state(
+            message=f"🔁 继续获取打折游戏 ID，已获取 {len(appids)} 个...",
+            progress=len(appids),
+            total=total_count or len(appids),
+        )
+    else:
+        _update_state(message=f"🕵️ 正在从 Steam 获取打折游戏列表 (上限 {max_count})...")
+        if checkpoint is not None:
+            checkpoint.update({
+                "phase": "discovering",
+                "status": "running",
+                "appids": [],
+                "done": [],
+                "failed": {},
+                "discovery_start": 0,
+                "total_count": None,
+                "consecutive_empty": 0,
+            })
+            _save_checkpoint(checkpoint)
     base_url = (
         "https://store.steampowered.com/search/results/"
         "?specials=1"          
@@ -194,13 +244,35 @@ def _get_discounted_appids(max_count: int = 20000, valid_proxies: Optional[list]
         "&json=1"
         "&count={count}&start={start}"
     )
-    consecutive_empty = 0
     while len(appids) < max_count:
+        if _pause_requested():
+            if checkpoint is not None:
+                checkpoint.update({
+                    "phase": "discovering",
+                    "status": "paused",
+                    "appids": appids,
+                    "discovery_start": start,
+                    "total_count": total_count,
+                    "consecutive_empty": consecutive_empty,
+                })
+                _save_checkpoint(checkpoint)
+            _update_state(message=f"⏸️ 已暂停：打折游戏 ID 已获取 {len(appids)} 个", progress=len(appids), total=total_count or len(appids))
+            return appids
         url = base_url.format(count=page_size, start=start)
         try:
             data = _fetch_with_proxy(url, valid_proxies or [], max_retries=5)
             if data is None:
                 consecutive_empty += 1
+                if checkpoint is not None:
+                    checkpoint.update({
+                        "phase": "discovering",
+                        "status": "running",
+                        "appids": appids,
+                        "discovery_start": start,
+                        "total_count": total_count,
+                        "consecutive_empty": consecutive_empty,
+                    })
+                    _save_checkpoint(checkpoint)
                 if consecutive_empty >= 3:
                     break
                 time.sleep(2)
@@ -230,16 +302,49 @@ def _get_discounted_appids(max_count: int = 20000, valid_proxies: Optional[list]
                     + (f"/{total_count}" if total_count else "")
                     + " 个打折游戏 ID..."
                 ),
-                total=len(appids),
+                progress=len(appids),
+                total=total_count or len(appids),
             )
             start += page_size
+            if checkpoint is not None:
+                checkpoint.update({
+                    "phase": "discovering",
+                    "status": "running",
+                    "appids": appids,
+                    "discovery_start": start,
+                    "total_count": total_count,
+                    "consecutive_empty": consecutive_empty,
+                })
+                _save_checkpoint(checkpoint)
             time.sleep(0.5)
         except Exception:
             consecutive_empty += 1
+            if checkpoint is not None:
+                checkpoint.update({
+                    "phase": "discovering",
+                    "status": "running",
+                    "appids": appids,
+                    "discovery_start": start,
+                    "total_count": total_count,
+                    "consecutive_empty": consecutive_empty,
+                })
+                _save_checkpoint(checkpoint)
             if consecutive_empty >= 3:
                 break
             time.sleep(2)
-    _update_state(message=f"✅ 获取到 {len(appids)} 个打折游戏 ID", total=len(appids))
+    if checkpoint is not None:
+        checkpoint.update({
+            "phase": "processing",
+            "status": "running",
+            "appids": appids,
+            "done": checkpoint.get("done", []),
+            "failed": checkpoint.get("failed", {}),
+            "discovery_start": start,
+            "total_count": total_count or len(appids),
+            "consecutive_empty": consecutive_empty,
+        })
+        _save_checkpoint(checkpoint)
+    _update_state(message=f"✅ 获取到 {len(appids)} 个打折游戏 ID", progress=len(appids), total=len(appids))
     return appids
 def _fetch_region_data(appid: str, cc_code: str, valid_proxies: list, max_region_retries: int = 3):
     """Fetch price data for a single game in a single region.
@@ -394,6 +499,7 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
     Designed to be called in a background thread.
     """
     from app.database import db_upsert_steam_deal, db_clear_steam_deals, db_delete_steam_deals_except
+    _clear_pause_request()
     with _fetch_lock:
         if _fetch_state["running"]:
             return
@@ -402,6 +508,7 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
             "progress": 0,
             "total": 0,
             "failed": 0,
+            "pause_requested": False,
             "message": "🚀 开始获取...",
         })
     try:
@@ -414,7 +521,19 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
             _update_state(message="⚠️ 无可用代理，尝试直连...")
         checkpoint = None if force_refresh else _load_checkpoint()
         resumed = bool(checkpoint)
-        if resumed:
+        if not checkpoint:
+            checkpoint = {
+                "version": CHECKPOINT_VERSION,
+                "status": "running",
+                "phase": "discovering",
+                "started_at": time.time(),
+                "appids": [],
+                "done": [],
+                "failed": {},
+                "force_refresh": bool(force_refresh),
+            }
+            _save_checkpoint(checkpoint)
+        if resumed and checkpoint.get("phase") != "discovering":
             appids = checkpoint.get("appids", [])
             done_set = set(checkpoint.get("done", []))
             failed_map = dict(checkpoint.get("failed", {}) or {})
@@ -425,22 +544,21 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
                 message=f"🔁 检测到未完成任务，继续扫描 {len(appids) - len(done_set)} 款游戏...",
             )
         else:
-            appids = _get_discounted_appids(max_count=20000, valid_proxies=valid_proxies)
+            appids = _get_discounted_appids(max_count=20000, valid_proxies=valid_proxies, checkpoint=checkpoint)
             done_set = set()
             failed_map = {}
-            if appids:
-                checkpoint = {
-                    "version": CHECKPOINT_VERSION,
-                    "status": "running",
-                    "started_at": time.time(),
-                    "appids": appids,
-                    "done": [],
-                    "failed": {},
-                    "force_refresh": bool(force_refresh),
-                }
-                _save_checkpoint(checkpoint)
+            if _pause_requested():
+                _update_state(
+                    running=False,
+                    pause_requested=False,
+                    progress=len(appids),
+                    total=checkpoint.get("total_count") or len(appids),
+                    message=f"⏸️ 已暂停：打折游戏 ID 已获取 {len(appids)} 个",
+                )
+                return
         if not appids:
-            _update_state(running=False, message="❌ 未获取到任何游戏 ID")
+            _clear_checkpoint()
+            _update_state(running=False, pause_requested=False, message="❌ 未获取到任何游戏 ID")
             return
         remaining_appids = [appid for appid in appids if str(appid) not in done_set]
         if not remaining_appids:
@@ -448,6 +566,7 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
             _clear_checkpoint()
             _update_state(
                 running=False,
+                pause_requested=False,
                 progress=len(appids),
                 total=len(appids),
                 failed=0,
@@ -470,53 +589,87 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
                     rates = json.load(f).get("rates", {})
         except Exception:
             pass
-        with ThreadPoolExecutor(max_workers=max_game_threads) as executor:
-            future_map = {
-                executor.submit(_process_single_game, appid, valid_proxies, max_region_threads, rates): appid
-                for appid in remaining_appids
-            }
-            count = len(done_set)
-            for future in as_completed(future_map):
-                appid = str(future_map[future])
-                count += 1
+        count = len(done_set)
+        appid_iter = iter(remaining_appids)
+        future_map = {}
+        pause_after_batch = False
+
+        def _save_processing_checkpoint(status: str = "running") -> None:
+            if checkpoint is not None:
+                checkpoint.update({
+                    "phase": "processing",
+                    "status": status,
+                    "appids": appids,
+                    "done": _ordered_done(),
+                    "failed": failed_map,
+                    "last_progress": count,
+                })
+                _save_checkpoint(checkpoint)
+
+        def _submit_more(executor: ThreadPoolExecutor) -> None:
+            while len(future_map) < max_game_threads and not _pause_requested():
                 try:
-                    game = future.result()
-                    if game is None:
-                        done_set.add(appid)
-                        failed_map.pop(appid, None)
+                    next_appid = next(appid_iter)
+                except StopIteration:
+                    break
+                future = executor.submit(_process_single_game, next_appid, valid_proxies, max_region_threads, rates)
+                future_map[future] = str(next_appid)
+
+        with ThreadPoolExecutor(max_workers=max_game_threads) as executor:
+            _submit_more(executor)
+            if _pause_requested() and not future_map:
+                pause_after_batch = True
+            while future_map:
+                done_futures, _pending = wait(future_map.keys(), return_when=FIRST_COMPLETED)
+                for future in done_futures:
+                    appid = str(future_map.pop(future))
+                    count += 1
+                    try:
+                        game = future.result()
+                        if game is None:
+                            done_set.add(appid)
+                            failed_map.pop(appid, None)
+                            _update_state(
+                                progress=count,
+                                failed=len(failed_map),
+                                message=f"⏭️ [{count}/{len(appids)}] 质量不达标，跳过",
+                            )
+                        else:
+                            db_upsert_steam_deal(game)
+                            done_set.add(appid)
+                            failed_map.pop(appid, None)
+                            _update_state(
+                                progress=count,
+                                failed=len(failed_map),
+                                message=f"✅ [{count}/{len(appids)}] {game['name']}",
+                            )
+                    except Exception as e:
+                        failed_map[appid] = str(e)[:120]
                         _update_state(
                             progress=count,
                             failed=len(failed_map),
-                            message=f"⏭️ [{count}/{len(appids)}] 质量不达标，跳过",
+                            message=f"⚠️ [{count}/{len(appids)}] 处理失败: {str(e)[:60]}",
                         )
-                    else:
-                        db_upsert_steam_deal(game)
-                        done_set.add(appid)
-                        failed_map.pop(appid, None)
-                        _update_state(
-                            progress=count,
-                            failed=len(failed_map),
-                            message=f"✅ [{count}/{len(appids)}] {game['name']}",
-                        )
-                except Exception as e:
-                    failed_map[appid] = str(e)[:120]
-                    _update_state(
-                        progress=count,
-                        failed=len(failed_map),
-                        message=f"⚠️ [{count}/{len(appids)}] 处理失败: {str(e)[:60]}",
-                    )
-                if checkpoint is not None:
-                    checkpoint.update({
-                        "status": "running",
-                        "appids": appids,
-                        "done": _ordered_done(),
-                        "failed": failed_map,
-                        "last_progress": count,
-                    })
-                    _save_checkpoint(checkpoint)
+                    _save_processing_checkpoint("running")
+                if _pause_requested():
+                    pause_after_batch = True
+                    _update_state(message=f"⏸️ 正在暂停：等待当前 {len(future_map)} 个游戏请求完成...")
+                if not pause_after_batch:
+                    _submit_more(executor)
+        if pause_after_batch:
+            _save_processing_checkpoint("paused")
+            _update_state(
+                running=False,
+                pause_requested=False,
+                progress=count,
+                failed=len(failed_map),
+                message=f"⏸️ 已暂停：已处理 {count}/{len(appids)} 款游戏",
+            )
+            return
         if failed_map:
             if checkpoint is not None:
                 checkpoint.update({
+                    "phase": "processing",
                     "status": "incomplete",
                     "done": _ordered_done(),
                     "failed": failed_map,
@@ -525,6 +678,7 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
                 _save_checkpoint(checkpoint)
             _update_state(
                 running=False,
+                pause_requested=False,
                 progress=count,
                 failed=len(failed_map),
                 message=f"⚠️ 本轮完成，仍有 {len(failed_map)} 款失败；再次点击可继续补扫",
@@ -534,6 +688,7 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
         _clear_checkpoint()
         _update_state(
             running=False,
+            pause_requested=False,
             failed=0,
             message=f"🎉 完成！共处理 {count} 款游戏，清理过期记录 {deleted} 款",
         )
@@ -543,4 +698,4 @@ def run_fetch(max_game_threads: int = 5, max_region_threads: int = 16, force_ref
             checkpoint["status"] = "interrupted"
             checkpoint["last_error"] = str(e)[:200]
             _save_checkpoint(checkpoint)
-        _update_state(running=False, message=f"❌ 抓取出错: {str(e)[:100]}")
+        _update_state(running=False, pause_requested=False, message=f"❌ 抓取出错: {str(e)[:100]}")

--- a/web/css/components.css
+++ b/web/css/components.css
@@ -4083,6 +4083,13 @@ textarea.app-modal-input {
   animation: breathePulse 2s ease-in-out infinite;
 }
 
+.sd-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .sd-fetch-btn {
   gap: 6px;
   padding: 8px 18px;

--- a/web/css/components.css
+++ b/web/css/components.css
@@ -4032,6 +4032,10 @@ textarea.app-modal-input {
   flex-wrap: wrap;
 }
 
+#panel-steam-deals {
+  padding-top: 10px;
+}
+
 .sd-header-left {
   display: flex;
   align-items: center;

--- a/web/index.html
+++ b/web/index.html
@@ -1573,13 +1573,18 @@
             <span id="steam-deals-total-count" class="sd-count-badge"></span>
             <span id="steam-deals-progress" class="sd-progress-badge hidden"></span>
           </div>
-          <button id="steam-deals-fetch-btn" class="btn btn-primary btn-sm sd-fetch-btn">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-              <polyline points="23 4 23 10 17 10"></polyline>
-              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
-            </svg>
-            获取数据
-          </button>
+          <div class="sd-header-actions">
+            <button id="steam-deals-fetch-btn" class="btn btn-primary btn-sm sd-fetch-btn">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+              </svg>
+              获取数据
+            </button>
+            <button id="steam-deals-reset-btn" class="btn btn-secondary btn-sm sd-fetch-btn" title="清空旧进度和旧数据后重新全量扫描">
+              重新扫描
+            </button>
+          </div>
         </div>
 
 

--- a/web/js/steamDeals.js
+++ b/web/js/steamDeals.js
@@ -19,6 +19,8 @@
     let _dealStatusFilter = '';
     let _pollTimer = null;
     let _initialized = false;
+    let _fetchRunning = false;
+    let _pauseRequested = false;
     const $ = id => document.getElementById(id);
     const esc = (value) => typeof escapeHtml === 'function'
         ? escapeHtml(value)
@@ -234,11 +236,14 @@
     function _resumeText(resume) {
         if (!resume?.has_checkpoint || !resume.total) return '';
         const failed = resume.failed ? `，失败 ${resume.failed}` : '';
-        return `可续扫：${resume.progress || 0}/${resume.total}${failed}`;
+        const phase = resume.phase === 'discovering' ? 'ID' : '游戏';
+        return `可续扫${phase}：${resume.progress || 0}/${resume.total}${failed}`;
     }
     async function fetchData(forceRefresh = false) {
         const btn = $('steam-deals-fetch-btn');
         const resetBtn = $('steam-deals-reset-btn');
+        _fetchRunning = true;
+        _pauseRequested = false;
         if (btn) { btn.disabled = true; btn.textContent = '获取中...'; }
         if (resetBtn) resetBtn.disabled = true;
         try {
@@ -254,8 +259,25 @@
             if (typeof toast === "function") {
                 toast("获取失败", err.message || "");
             }
+            _fetchRunning = false;
             if (btn) { btn.disabled = false; btn.innerHTML = REFRESH_SVG + ' 获取数据'; }
             if (resetBtn) resetBtn.disabled = false;
+        }
+    }
+    async function pauseFetch() {
+        const btn = $('steam-deals-fetch-btn');
+        if (btn) { btn.disabled = true; btn.textContent = '正在暂停...'; }
+        _pauseRequested = true;
+        try {
+            const resp = await fetch('/api/steam-deals/pause', { method: 'POST' });
+            const r = await resp.json();
+            if (!r.ok) throw new Error(r.error || '暂停失败');
+            startPolling();
+        } catch (err) {
+            console.error('暂停失败:', err);
+            _pauseRequested = false;
+            if (typeof toast === "function") toast("暂停失败", err.message || "");
+            if (btn) { btn.disabled = false; btn.textContent = '暂停扫描'; }
         }
     }
     function startPolling() {
@@ -273,10 +295,17 @@
             const resetBtn = $('steam-deals-reset-btn');
             const tcEl = $('steam-deals-total-count');
             if (s.running) {
+                _fetchRunning = true;
+                _pauseRequested = !!s.pause_requested;
                 if (prog) { prog.classList.remove('hidden'); prog.textContent = s.message || `${s.progress}/${s.total}`; }
-                if (btn) { btn.disabled = true; btn.textContent = '获取中...'; }
+                if (btn) {
+                    btn.disabled = _pauseRequested;
+                    btn.textContent = _pauseRequested ? '正在暂停...' : '暂停扫描';
+                }
                 if (resetBtn) resetBtn.disabled = true;
             } else {
+                _fetchRunning = false;
+                _pauseRequested = false;
                 if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
                 const resumeInfo = _resumeText(s.resume);
                 if (prog) {
@@ -345,7 +374,10 @@
             loadGames(true);
         });
         const fetchBtn = $('steam-deals-fetch-btn');
-        if (fetchBtn) fetchBtn.addEventListener('click', () => fetchData(false));
+        if (fetchBtn) fetchBtn.addEventListener('click', () => {
+            if (_fetchRunning) pauseFetch();
+            else fetchData(false);
+        });
         const resetBtn = $('steam-deals-reset-btn');
         if (resetBtn) resetBtn.addEventListener('click', () => {
             const ok = window.confirm('重新扫描会清空当前断点进度和已有 Steam 折扣数据，然后全量重扫。确定继续吗？');

--- a/web/js/steamDeals.js
+++ b/web/js/steamDeals.js
@@ -231,11 +231,19 @@
         _observer.observe(sentinel);
     }
     const REFRESH_SVG = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="23 4 23 10 17 10"></polyline><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path></svg>`;
-    async function fetchData() {
+    function _resumeText(resume) {
+        if (!resume?.has_checkpoint || !resume.total) return '';
+        const failed = resume.failed ? `，失败 ${resume.failed}` : '';
+        return `可续扫：${resume.progress || 0}/${resume.total}${failed}`;
+    }
+    async function fetchData(forceRefresh = false) {
         const btn = $('steam-deals-fetch-btn');
+        const resetBtn = $('steam-deals-reset-btn');
         if (btn) { btn.disabled = true; btn.textContent = '获取中...'; }
+        if (resetBtn) resetBtn.disabled = true;
         try {
-            const resp = await fetch('/api/steam-deals/fetch', { method: 'POST' });
+            const url = forceRefresh ? '/api/steam-deals/fetch?force_refresh=true' : '/api/steam-deals/fetch';
+            const resp = await fetch(url, { method: 'POST' });
             const r = await resp.json();
             if (!r.ok) {
                 throw new Error(r.error || "获取失败");
@@ -247,6 +255,7 @@
                 toast("获取失败", err.message || "");
             }
             if (btn) { btn.disabled = false; btn.innerHTML = REFRESH_SVG + ' 获取数据'; }
+            if (resetBtn) resetBtn.disabled = false;
         }
     }
     function startPolling() {
@@ -261,14 +270,28 @@
             const prog = $('steam-deals-progress');
             const info = $('steam-deals-update-info');
             const btn = $('steam-deals-fetch-btn');
+            const resetBtn = $('steam-deals-reset-btn');
             const tcEl = $('steam-deals-total-count');
             if (s.running) {
                 if (prog) { prog.classList.remove('hidden'); prog.textContent = s.message || `${s.progress}/${s.total}`; }
                 if (btn) { btn.disabled = true; btn.textContent = '获取中...'; }
+                if (resetBtn) resetBtn.disabled = true;
             } else {
                 if (_pollTimer) { clearInterval(_pollTimer); _pollTimer = null; }
-                if (prog) prog.classList.add('hidden');
-                if (btn) { btn.disabled = false; btn.innerHTML = REFRESH_SVG + ' 获取数据'; }
+                const resumeInfo = _resumeText(s.resume);
+                if (prog) {
+                    if (resumeInfo) {
+                        prog.classList.remove('hidden');
+                        prog.textContent = resumeInfo;
+                    } else {
+                        prog.classList.add('hidden');
+                    }
+                }
+                if (btn) {
+                    btn.disabled = false;
+                    btn.innerHTML = REFRESH_SVG + (s.resume?.has_checkpoint ? ' 继续扫描' : ' 获取数据');
+                }
+                if (resetBtn) resetBtn.disabled = false;
                 loadGames(true);
             }
             if (info) {
@@ -285,7 +308,7 @@
             if (s.running) { startPolling(); return; }
             if (s.last_update && s.auto_refresh_days > 0) {
                 const days = (Date.now() / 1000 - s.last_update) / 86400;
-                if (days >= s.auto_refresh_days) fetchData();
+                if (days >= s.auto_refresh_days) fetchData(false);
             }
         } catch (err) { }
     }
@@ -322,7 +345,12 @@
             loadGames(true);
         });
         const fetchBtn = $('steam-deals-fetch-btn');
-        if (fetchBtn) fetchBtn.addEventListener('click', fetchData);
+        if (fetchBtn) fetchBtn.addEventListener('click', () => fetchData(false));
+        const resetBtn = $('steam-deals-reset-btn');
+        if (resetBtn) resetBtn.addEventListener('click', () => {
+            const ok = window.confirm('重新扫描会清空当前断点进度和已有 Steam 折扣数据，然后全量重扫。确定继续吗？');
+            if (ok) fetchData(true);
+        });
         setupObserver();
 
         const grid = $('steam-deals-grid');


### PR DESCRIPTION
## 变更内容

- 为 Steam 折扣抓取增加 `config/steam_deals_checkpoint.json` 断点文件，抓取过程中持续保存进度。
- AppID 发现阶段也支持断点：每页 Steam specials 结果都会保存已获取 ID、下一页 offset、total_count 等信息。
- 默认“获取/继续扫描”不再开局清空旧数据；中断或暂停后再次点击会从 checkpoint 继续。
- 扫描运行中主按钮切换为“暂停扫描”，调用 `/api/steam-deals/pause` 后优雅暂停：
  - ID 阶段会在当前页请求后暂停。
  - 游戏详情阶段会停止投递新游戏，等待当前并发批次完成后保存进度。
- 新增“重新扫描”按钮，确认后清空旧断点和旧折扣数据，再进行全量扫描。
- 成功完成整轮扫描后，按本轮 Steam specials appid 集合清理已不在打折列表中的旧记录。
- `/api/steam-deals/status` 返回 `resume.phase` 与 `pause_requested`，前端可显示“可续扫ID/游戏 x/y”。
- 修复 Steam 折扣面板顶部状态徽章的呼吸绿圈被标题栏/滚动容器裁切的问题。
- 忽略运行期 checkpoint 文件，避免误提交本地扫描进度。

## 原因

原逻辑每次抓取都会先 `db_clear_steam_deals()`，进度只存在内存里；长时间扫描一旦进程退出、网络中断或用户想临时停下，就只能从零开始，还会先删掉已有数据。

## 备注

Codex写的，测过了没问题