### PR TITLE
[codex] 等待代理池预热后再发送代理请求

### DIFF
--- a/utils/proxy_manager.py
+++ b/utils/proxy_manager.py
@@ -63,12 +63,15 @@ def test_one_proxy(proxy_cfg: dict, test_url: str, timeout: int) -> dict:
 class ProxyManager:
     def __init__(self):
         self._lock = threading.Lock()
+        self._warmup_done = threading.Event()
+        self._warmup_done.set()
         self._proxy_configs: list = []
         self._proxy_weights: list = []
         self._proxies: list = []
         self._warming_up: bool = False
         self._last_disabled_proxy_log_key = None
         self._last_disabled_proxy_log_at = 0.0
+        self._last_empty_proxy_log_at = 0.0
         self._reload()
         _pm_log(
             f"[ProxyManager] 初始化完成: "
@@ -76,6 +79,8 @@ class ProxyManager:
             f"已启用={self.is_proxy_enabled()} "
             f"策略={self.get_strategy()}"
         )
+        if self.is_proxy_enabled() and self._proxies:
+            threading.Thread(target=self.warmup, daemon=True, name="proxy-warmup-init").start()
     def _reload(self):
         cfg = _load_proxy_pool_cfg()
         raw = cfg.get("proxies", [])
@@ -83,6 +88,10 @@ class ProxyManager:
         self._cached_strategy = int(cfg.get("strategy", 1))
         self._cached_enabled = bool(cfg.get("enabled", False))
         self._sync_cycle()
+        if self.is_proxy_enabled() and self._proxies and not self._has_usable_proxy_locked():
+            self._warmup_done.clear()
+        else:
+            self._warmup_done.set()
     def _sync_cycle(self):
         self._proxies.sort(key=lambda x: x["score"], reverse=True)
         # 按评分构建权重列表，score=0的节点权重为0，永远不被选中
@@ -114,54 +123,94 @@ class ProxyManager:
                 _pm_log(
                     f"[ProxyManager] 代理池未启用(enabled={enabled}, strategy={strategy}, 代理数={proxy_count})，跳过预热"
                 )
+                self._warmup_done.set()
                 return
             self._warming_up = True
+            self._warmup_done.clear()
             proxies_snapshot = list(self._proxies)
         if not proxies_snapshot:
             with self._lock:
                 self._warming_up = False
+                self._warmup_done.set()
             return
-        _pm_log(f"[ProxyManager] 开始预热和检测代理池，共 {len(proxies_snapshot)} 个代理...")
-        cfg = _load_proxy_pool_cfg()
-        test_url = cfg.get("test_url", "https://ipv4.webshare.io/")
-        timeout = int(cfg.get("timeout_seconds", 10))
-        results_map = {}
-        max_workers = min(len(proxies_snapshot), 20)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_proxy = {
-                executor.submit(test_one_proxy, p["config"], test_url, timeout): p["config"]
-                for p in proxies_snapshot
-            }
-            for future in as_completed(future_to_proxy):
-                config = future_to_proxy[future]
-                key = (config.get("host"), config.get("port"))
-                try:
-                    res = future.result()
-                    if res["status"] == "ok":
-                        score = max(1, 100000 - res["latency_ms"])
-                    else:
+        try:
+            _pm_log(f"[ProxyManager] 开始预热和检测代理池，共 {len(proxies_snapshot)} 个代理...")
+            cfg = _load_proxy_pool_cfg()
+            test_url = cfg.get("test_url", "https://ipv4.webshare.io/")
+            timeout = int(cfg.get("timeout_seconds", 10))
+            results_map = {}
+            max_workers = min(len(proxies_snapshot), 20)
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_proxy = {
+                    executor.submit(test_one_proxy, p["config"], test_url, timeout): p["config"]
+                    for p in proxies_snapshot
+                }
+                for future in as_completed(future_to_proxy):
+                    config = future_to_proxy[future]
+                    key = (config.get("host"), config.get("port"))
+                    try:
+                        res = future.result()
+                        if res["status"] == "ok":
+                            score = max(1, 100000 - res["latency_ms"])
+                        else:
+                            score = 0
+                    except Exception:
                         score = 0
-                except Exception:
-                    score = 0
-                results_map[key] = score
-        with self._lock:
-            for p in self._proxies:
-                key = (p["config"].get("host"), p["config"].get("port"))
-                if key in results_map:
-                    p["score"] = results_map[key]
-            self._sync_cycle()
-            self._warming_up = False
-        _pm_log(f"[ProxyManager] 预热和检测代理池完成，已按评分降序重载代理循环队列。")
+                    results_map[key] = score
+            with self._lock:
+                for p in self._proxies:
+                    key = (p["config"].get("host"), p["config"].get("port"))
+                    if key in results_map:
+                        p["score"] = results_map[key]
+                self._sync_cycle()
+            _pm_log("[ProxyManager] 预热和检测代理池完成，已按评分降序重载代理循环队列。")
+        finally:
+            with self._lock:
+                self._warming_up = False
+                self._warmup_done.set()
     def get_strategy(self) -> int:
         return self._cached_strategy
     def is_proxy_enabled(self) -> bool:
         return self._cached_enabled and self._cached_strategy != 3
+    def _has_usable_proxy_locked(self) -> bool:
+        return bool(self._proxy_configs) and any(w > 0 for w in self._proxy_weights)
+    def _ensure_warmup_ready(self) -> None:
+        """Wait for proxy warmup before selecting a proxy.
+
+        Scores stay at 0 until a proxy passes validation, so callers using
+        strategy 2 should not race ahead and treat the pool as empty while the
+        initial warmup is still pending.
+        """
+        while True:
+            with self._lock:
+                needs_warmup = (
+                    self.is_proxy_enabled()
+                    and bool(self._proxies)
+                    and not self._has_usable_proxy_locked()
+                )
+                if not needs_warmup:
+                    return
+                warming_up = self._warming_up
+                warmup_done = self._warmup_done
+            if warming_up:
+                _pm_log("[ProxyManager] 代理池正在预热，当前请求等待预热完成...")
+                warmup_done.wait()
+                return
+            _pm_log("[ProxyManager] 代理池尚未预热，当前请求同步等待预热完成...")
+            self.warmup()
+            return
+    def _log_empty_proxy_once(self) -> None:
+        now = time.time()
+        if now - self._last_empty_proxy_log_at >= 10:
+            _pm_log("[ProxyManager] get_next_proxy_dict → 代理池为空或全部失败，返回 None")
+            self._last_empty_proxy_log_at = now
     def get_next_proxy_dict(self):
+        self._ensure_warmup_ready()
         with self._lock:
             configs = self._proxy_configs
             weights = self._proxy_weights
             if not configs or all(w == 0 for w in weights):
-                _pm_log("[ProxyManager] get_next_proxy_dict → 代理池为空或全部失败，返回 None")
+                self._log_empty_proxy_once()
                 return None
             # 按评分加权随机选：延迟低（高分）的代理被选中概率更高
             p = random.choices(configs, weights=weights, k=1)[0]


### PR DESCRIPTION
## 变更内容

- ProxyManager 初始化后，如果代理池启用且有代理，会启动后台预热。
- 当策略 2（始终代理）或失败切代理需要取代理时，如果当前没有可用评分代理：
  - 若代理池正在预热，则等待预热完成后再选代理。
  - 若尚未预热，则同步执行一次预热后再选代理。
- 不给未验证代理默认 `score=1`，只有通过 `test_one_proxy()` 的代理才进入可选权重池。
- 对“代理池为空或全部失败”日志做 10 秒节流，避免后台任务刷屏。

## 原因

现有逻辑中代理配置加载后所有 `score=0`，但请求可能在 warmup 完成前进入 `get_next_proxy_dict()`。此时即使配置里有 100 个代理，也会因为权重全为 0 被误判为“代理池为空或全部失败”。在策略 2 下，后台出售/Steam 请求会反复打印 `None(池空)`。

这次改为请求侧等待预热结果，避免把未验证代理直接放行，也避免预热竞态导致的假“池空”。

## 验证

- `\.venv\Scripts\python.exe -m py_compile utils\proxy_manager.py`
- 模拟可用代理：`test_one_proxy()` 延迟返回 ok，`get_proxies_for_request()` 会等待 warmup 后返回代理。
- 模拟劣质代理：`test_one_proxy()` 返回 failed，warmup 后仍返回 None，不会默认使用坏代理。