### PR TITLE
fix: 修正 BUFF 支付宝渠道错误映射到信用卡花呗

### DIFF
--- a/buff/buyer.py
+++ b/buff/buyer.py
@@ -173,7 +173,9 @@ def _looks_like_html(headers, text: str) -> bool:
 def _html_looks_like_login(text: str) -> bool:
     lowered = str(text or "").lower()
     return any(marker in lowered for marker in ("/login", "登录", "未登录", "sign in"))
-PAY_METHOD_ALIPAY = 51
+# BUFF labels 49 as the general Alipay channel.  Method 51 is the separate
+# "Alipay - credit card/Huabei" channel and must not be used as the default.
+PAY_METHOD_ALIPAY = 49
 PAY_METHOD_WECHAT = 6
 API_HISTORY = "https://buff.163.com/api/market/buy_order/history"
 API_USER_INFO = "https://buff.163.com/account/api/user/info/v2"

--- a/tests/test_buff_request_policy.py
+++ b/tests/test_buff_request_policy.py
@@ -15,6 +15,7 @@ from buff.buyer import (
     API_USER_INFO,
     API_WX_PAY_QRCODE,
     DEFAULT_USER_AGENT,
+    PAY_METHOD_ALIPAY,
     PAY_METHOD_WECHAT,
     BuffBuyer,
 )
@@ -107,7 +108,7 @@ def user_info_response(*, steam_id=STEAM_ID):
     )
 
 
-def buy_preview_response(*, pay_method=51, btn_clickable=True):
+def buy_preview_response(*, pay_method=PAY_METHOD_ALIPAY, btn_clickable=True):
     return FakeResponse(
         {
             "code": "OK",
@@ -123,7 +124,7 @@ def buy_preview_response(*, pay_method=51, btn_clickable=True):
     )
 
 
-def checkout_responses(*after_preview, pay_method=51):
+def checkout_responses(*after_preview, pay_method=PAY_METHOD_ALIPAY):
     """Responses required before and after a single-item checkout POST."""
 
     return (
@@ -144,6 +145,12 @@ def test_default_user_agent_is_stable_and_can_be_overridden():
     assert second.headers["User-Agent"] == DEFAULT_USER_AGENT
     assert custom.headers["User-Agent"] == "Browser/7"
     assert custom.user_agent == "Browser/7"
+
+
+def test_generic_alipay_uses_wallet_channel_not_credit_card_huabei():
+    # BUFF currently exposes 49 as "Alipay" and 51 as the distinct
+    # "Alipay - credit card/Huabei" channel.
+    assert PAY_METHOD_ALIPAY == 49
 
 
 def test_close_only_releases_an_internally_owned_session(monkeypatch):
@@ -720,7 +727,7 @@ def test_every_order_creating_write_rejects_malformed_success_data(
     ]
 
 
-@pytest.mark.parametrize("pay_method", [51, PAY_METHOD_WECHAT])
+@pytest.mark.parametrize("pay_method", [PAY_METHOD_ALIPAY, PAY_METHOD_WECHAT])
 def test_execute_preflights_user_info_and_clickable_payment_method_before_post(
     pay_method,
 ):
@@ -775,8 +782,8 @@ def test_known_steam_id_skips_user_info_but_never_skips_buy_preview():
     [
         [],
         [{"value": 6, "btn_clickable": True}],
-        [{"value": 51, "btn_clickable": False}],
-        [{"value": 51}],
+        [{"value": PAY_METHOD_ALIPAY, "btn_clickable": False}],
+        [{"value": PAY_METHOD_ALIPAY}],
     ],
 )
 @pytest.mark.parametrize(
@@ -843,7 +850,9 @@ def test_buy_reuses_server_cashier_trace_and_current_browser_write_headers():
         {
             "code": "OK",
             "data": {
-                "pay_methods": [{"value": 51, "btn_clickable": True}]
+                "pay_methods": [
+                    {"value": PAY_METHOD_ALIPAY, "btn_clickable": True}
+                ]
             },
         },
         headers={"Buff-Cashier-Trace-ID": "server-issued-trace"},


### PR DESCRIPTION
## 问题

当前默认支付宝渠道被映射到 BUFF 支付方式 51。根据 BUFF 当前购买预检返回值：

- 49：支付宝支付
- 51：支付宝-信用卡花呗（含 1% 支付渠道服务费）

因此程序下单会固定进入信用卡/花呗渠道；停用信用卡后，即使支付宝余额、余额宝或借记卡可用，订单仍会支付失败。

## 修改

- 将默认支付宝支付方式从 51 改为通用支付宝渠道 49
- 更新支付请求策略测试中的渠道数据
- 增加回归测试，防止默认支付宝重新指向信用卡/花呗渠道

## 验证

- 支付请求策略测试：99 passed
- 全量测试：447 passed
- 使用已登录 BUFF 会话执行只读购买预检：渠道 49 被 BUFF 接受并返回可用
- 验证过程未创建订单或触发支付

此 PR 修复 #48 中“支付宝支付会锁定信用卡支付”的部分；Issue 中的批量锁单和支付后自动报价问题不在本 PR 范围内。

Refs #48