### PR TITLE
fix: 修复库存解禁时间解析与显示格式

### DIFF
--- a/app/inventory_cs2.py
+++ b/app/inventory_cs2.py
@@ -20,6 +20,10 @@ def _parse_cooldown(owner_descriptions: List[dict]) -> Tuple[str, float]:
         if "trade-protected" not in val:
             continue
         text = val
+        date_match = re.search(r"\[date\](\d+)\[/date\]", val)
+        if date_match:
+            ts = float(date_match.group(1))
+            break
         m = re.search(r"until (.+?) GMT", val)
         if not m:
             break

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -270,12 +270,16 @@ async function refreshInventory(forceRefresh = true) {
       const tradeHtml =
         `<span class="${it.can_trade ? "text-ok" : "text-bad"}">${it.can_trade ? "是" : "否"}</span>` +
         (it.tradable ? "" : ' <span class="text-bad">(不可交易)</span>');
-      const rawTime = it.cooldown_at_iso || it.cooldown_text || "";
-      let displayTime = rawTime;
-      if (it.cooldown_at_iso) {
-        const d = new Date(it.cooldown_at_iso);
+      // Also extract timestamps from inventory cached before the backend parser fix.
+      const dateMatch = (it.cooldown_text || "").match(/\[date\](\d+)\[\/date\]/);
+      const cooldownSeconds = Number(it.cooldown_at || (dateMatch && dateMatch[1]));
+      const rawTime = it.cooldown_at_iso || (cooldownSeconds > 0 ? cooldownSeconds * 1000 : null);
+      let displayTime = "";
+      if (rawTime !== null) {
+        const d = new Date(rawTime);
         if (!isNaN(d.getTime())) {
-          displayTime = d.toLocaleString();
+          const pad = (value) => String(value).padStart(2, "0");
+          displayTime = `${String(d.getFullYear()).padStart(4, "0")}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
         }
       }
       const timeHtml = displayTime ? `<span class="text-bad">${escapeHtml(displayTime)}</span>` : "—";


### PR DESCRIPTION
Steam 库存返回 `[date]1789106400[/date]` 时，原解析器无法提取解禁时间，导致“解禁时间”列显示完整交易保护说明。

后端现在提取 BBCode 中的 Unix 秒级时间戳，并保留旧 GMT 格式兼容；前端按浏览器本地时区固定显示为 `YYYY/MM/DD HH:mm:ss`，同时兼容旧库存缓存中的日期标签。以 UTC+8 为例，`1789106400` 显示为 `2026/09/11 14:00:00`。状态说明保留原文，无有效时间时显示破折号。

验证：已通过后端 BBCode、旧 GMT 和空值解析检查，以及前端 ISO、秒级时间戳、缓存 BBCode、补零、空值和无效日期检查；独立 PR 分支通过 `node --check web/js/main.js` 和 `git diff --check`。
